### PR TITLE
Fix mysql header include having extra "mysql/" prefix

### DIFF
--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -25,7 +25,7 @@
  */
 
 #include <iostream>
-#include <mysql/errmsg.h>
+#include <errmsg.h>
 #include <sqlpp11/exception.h>
 #include <sqlpp11/mysql/bind_result.h>
 #include "detail/prepared_statement_handle.h"


### PR DESCRIPTION
libmysqlclient does not prefix headers with mysql. I believe there was a set of commits before that removed most of the places in which mysql includes were using an extra `mysql/` prefix but this file seems to have been missed.
