### PR TITLE
Include the implementation for unsigned integral types.

### DIFF
--- a/include/sqlpp11/mysql/bind_result.h
+++ b/include/sqlpp11/mysql/bind_result.h
@@ -91,6 +91,7 @@ namespace sqlpp
       void _bind_boolean_result(size_t index, signed char* value, bool* is_null);
       void _bind_floating_point_result(size_t index, double* value, bool* is_null);
       void _bind_integral_result(size_t index, int64_t* value, bool* is_null);
+      void _bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null);
       void _bind_text_result(size_t index, const char** text, size_t* len);
       void _bind_date_result(size_t index, ::sqlpp::chrono::day_point* value, bool* is_null);
       void _bind_date_time_result(size_t index, ::sqlpp::chrono::microsecond_point* value, bool* is_null);
@@ -102,6 +103,9 @@ namespace sqlpp
       {
       }
       void _post_bind_integral_result(size_t index, int64_t* value, bool* is_null)
+      {
+      }
+      void _post_bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null)
       {
       }
       void _post_bind_text_result(size_t index, const char** text, size_t* len)

--- a/include/sqlpp11/mysql/char_result.h
+++ b/include/sqlpp11/mysql/char_result.h
@@ -104,6 +104,12 @@ namespace sqlpp
         *value = (*is_null ? 0 : std::strtoll(_char_result_row.data[index], nullptr, 10));
       }
 
+      void _bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null)
+      {
+        *is_null = (_char_result_row.data == nullptr or _char_result_row.data[index] == nullptr);
+        *value = (*is_null ? 0 : std::strtoull(_char_result_row.data[index], nullptr, 10));
+      }
+
       void _bind_text_result(size_t index, const char** value, size_t* len)
       {
         bool is_null = (_char_result_row.data == nullptr or _char_result_row.data[index] == nullptr);

--- a/include/sqlpp11/mysql/prepared_statement.h
+++ b/include/sqlpp11/mysql/prepared_statement.h
@@ -65,6 +65,7 @@ namespace sqlpp
 
       void _bind_boolean_parameter(size_t index, const signed char* value, bool is_null);
       void _bind_integral_parameter(size_t index, const int64_t* value, bool is_null);
+      void _bind_unsigned_integral_parameter(size_t index, const uint64_t* value, bool is_null);
       void _bind_floating_point_parameter(size_t index, const double* value, bool is_null);
       void _bind_text_parameter(size_t index, const std::string* value, bool is_null);
       void _bind_date_parameter(size_t index, const ::sqlpp::chrono::day_point* value, bool is_null);

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -82,6 +82,26 @@ namespace sqlpp
       param.error = &meta_data.bound_error;
     }
 
+    void bind_result_t::_bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null)
+    {
+      if (_handle->debug)
+        std::cerr << "MySQL debug: binding unsigned integral result " << *value << " at index: " << index << std::endl;
+
+      detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+      meta_data.index = index;
+      meta_data.len = nullptr;
+      meta_data.is_null = is_null;
+
+      MYSQL_BIND& param = _handle->result_params[index];
+      param.buffer_type = MYSQL_TYPE_LONGLONG;
+      param.buffer = value;
+      param.buffer_length = sizeof(*value);
+      param.length = &meta_data.bound_len;
+      param.is_null = &meta_data.bound_is_null;
+      param.is_unsigned = true;
+      param.error = &meta_data.bound_error;
+    }
+
     void bind_result_t::_bind_floating_point_result(size_t index, double* value, bool* is_null)
     {
       if (_handle->debug)

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -87,6 +87,22 @@ namespace sqlpp
       param.error = nullptr;
     }
 
+    void prepared_statement_t::_bind_unsigned_integral_parameter(size_t index, const uint64_t* value, bool is_null)
+    {
+      if (_handle->debug)
+        std::cerr << "MySQL debug: binding unsigned integral parameter " << *value << " at index: " << index << ", being "
+                  << (is_null ? "" : "not ") << "null" << std::endl;
+      _handle->stmt_param_is_null[index] = is_null;
+      MYSQL_BIND& param = _handle->stmt_params[index];
+      param.buffer_type = MYSQL_TYPE_LONGLONG;
+      param.buffer = const_cast<uint64_t*>(value);
+      param.buffer_length = sizeof(*value);
+      param.length = &param.buffer_length;
+      param.is_null = &_handle->stmt_param_is_null[index];
+      param.is_unsigned = true;
+      param.error = nullptr;
+    }
+
     void prepared_statement_t::_bind_floating_point_parameter(size_t index, const double* value, bool is_null)
     {
       if (_handle->debug)


### PR DESCRIPTION
Otherwise it fails to compile if `sqlpp::integer_unsigned` is used on a column traits.