### PR TITLE
Added the ability to disable compiling unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ cmake_minimum_required(VERSION 3.2)
 include(CheckCXXSymbolExists)
 project (sqlpp11-connector-mysql)
 enable_testing()
+
+option(ENABLE_TESTS "Build unit tests" On)
 set(CMAKE_CXX_STANDARD 11)
 
 check_cxx_symbol_exists(_LIBCPP_VERSION iostream HAS_LIBCPP_VERSION)
@@ -76,7 +78,11 @@ file(GLOB_RECURSE sqlpp_headers ${include_dir}/*.h ${SQLPP11_INCLUDE_DIR}/*.h)
 include_directories(${include_dir})
 
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if(ENABLE_TESTS)
+  add_subdirectory(tests)
+endif()
+
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/sqlpp11" DESTINATION include)
 


### PR DESCRIPTION
Updated CMakeLists.txt so you can disable building unit tests just like how sqlpp11 allows you to disable them.