### PR TITLE
Fix windows build error

### DIFF
--- a/include/sqlpp11/mysql/char_result.h
+++ b/include/sqlpp11/mysql/char_result.h
@@ -27,6 +27,7 @@
 #ifndef SQLPP_MYSQL_CHAR_RESULT_H
 #define SQLPP_MYSQL_CHAR_RESULT_H
 
+#include <ciso646>
 #include <cstdlib>
 #include <memory>
 #include <sqlpp11/chrono.h>


### PR DESCRIPTION
OS: windows
Arch: x64
Compiler: VS2017 Community Update 5
Connector: Mysql 5.7 Connector/C
Standard: C++-17

Fixes error:

```
    sqlpp11-connector-mysql\include\sqlpp11/mysql/char_result.h(90): error C2146: syntax error: missing ')' before identifier 'or'
    sqlpp11-connector-mysql\include\sqlpp11/mysql/char_result.h(92): error C2146: syntax error: missing ')' before identifier 'or'
    sqlpp11-connector-mysql\include\sqlpp11/mysql/char_result.h(97): error C2146: syntax error: missing ')' before identifier 'or'
    sqlpp11-connector-mysql\include\sqlpp11/mysql/char_result.h(103): error C2146: syntax error: missing ')' before identifier 'or'
    sqlpp11-connector-mysql\include\sqlpp11/mysql/char_result.h(109): error C2146: syntax error: missing ')' before identifier 'or'
    sqlpp11-connector-mysql\include\sqlpp11/mysql/char_result.h(115): error C2146: syntax error: missing ')' before identifier 'or'
    sqlpp11-connector-mysql\include\sqlpp11/mysql/connection_config.h(53): error C2146: syntax error: missing ')' before identifier 'and'
```