### PR TITLE
Call `mysql_select_db` after `reconnect()` or else subsequent queries fail with no database selected

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,6 +18,7 @@ ColumnLimit:     120
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
 IndentCaseLabels: true
 IndentWrappedFunctionNames: false
 IndentFunctionDeclarationAfterType: false

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -154,15 +154,6 @@ namespace sqlpp
     connection::connection(const std::shared_ptr<connection_config>& config)
         : _handle(new detail::connection_handle_t(config))
     {
-      if (mysql_set_character_set(_handle->mysql.get(), _handle->config->charset.c_str()))
-      {
-        throw sqlpp::exception("MySQL error: can't set character set " + _handle->config->charset);
-      }
-
-      if (mysql_select_db(_handle->mysql.get(), _handle->config->database.c_str()))
-      {
-        throw sqlpp::exception("MySQL error: can't select database '" + _handle->config->database + "'");
-      }
     }
 
     connection::~connection()

--- a/src/detail/connection_handle.cpp
+++ b/src/detail/connection_handle.cpp
@@ -35,6 +35,27 @@ namespace sqlpp
   {
     namespace detail
     {
+      void connect(MYSQL* mysql, const connection_config& config)
+      {
+        if (!mysql_real_connect(mysql, config.host.empty() ? nullptr : config.host.c_str(),
+                                config.user.empty() ? nullptr : config.user.c_str(),
+                                config.password.empty() ? nullptr : config.password.c_str(), nullptr, config.port,
+                                config.unix_socket.empty() ? nullptr : config.unix_socket.c_str(), config.client_flag))
+        {
+          throw sqlpp::exception("MySQL: could not connect to server: " + std::string(mysql_error(mysql)));
+        }
+
+        if (mysql_set_character_set(mysql, config.charset.c_str()))
+        {
+          throw sqlpp::exception("MySQL error: can't set character set " + config.charset);
+        }
+
+        if (mysql_select_db(mysql, config.database.c_str()))
+        {
+          throw sqlpp::exception("MySQL error: can't select database '" + config.database + "'");
+        }
+      }
+
       void handle_cleanup(MYSQL* mysql)
       {
         mysql_close(mysql);
@@ -57,14 +78,7 @@ namespace sqlpp
           }
         }
 
-        if (!mysql_real_connect(mysql.get(), config->host.empty() ? nullptr : config->host.c_str(),
-                                config->user.empty() ? nullptr : config->user.c_str(),
-                                config->password.empty() ? nullptr : config->password.c_str(), nullptr, config->port,
-                                config->unix_socket.empty() ? nullptr : config->unix_socket.c_str(),
-                                config->client_flag))
-        {
-          throw sqlpp::exception("MySQL: could not connect to server: " + std::string(mysql_error(mysql.get())));
-        }
+        connect(mysql.get(), *config);
       }
 
       connection_handle_t::~connection_handle_t()
@@ -78,14 +92,7 @@ namespace sqlpp
 
       void connection_handle_t::reconnect()
       {
-        if (!mysql_real_connect(mysql.get(), config->host.empty() ? nullptr : config->host.c_str(),
-                                config->user.empty() ? nullptr : config->user.c_str(),
-                                config->password.empty() ? nullptr : config->password.c_str(), nullptr, config->port,
-                                config->unix_socket.empty() ? nullptr : config->unix_socket.c_str(),
-                                config->client_flag))
-        {
-          throw sqlpp::exception("MySQL: could not connect to server: " + std::string(mysql_error(mysql.get())));
-        }
+        connect(mysql.get(), *config);
       }
     }
   }


### PR DESCRIPTION
With a small code snippet that reconnects on query failure (see below), plus manual stop/start of the local MariaDB server, I confirmed that after reconnect (i.e. another call to `mysql_real_connect` in case the connection is broken), no database is selected anymore. That is because `mysql_select_db` does a remote call into the server which keeps this setting as part of the connection context. This was problematic in a production setting where errors like `MySQL error: Could not execute MySQL-statement: No database selected (statement was >>SELECT [...]<<)` appeared late after deployment.

The proposed patch sets the desired database after every call to `mysql_real_connect`. Didn't change the code to use `mysql_real_connect`'s `db` parameter since I don't know which implications this has (permissions checked at connection time?).

```cpp
// ls ex.c | entr sh -c '~/bin/cmd_k && clang
// -I/usr/local/Cellar/mariadb/10.3.12/include/mysql
// -L/usr/local/Cellar/mariadb/10.3.12/lib/ -lmysqlclient_r ex.c && ./a.out &&
// echo OK || echo FAIL'

#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>

#include <mysql.h>

int main(int argc, char **argv) {
  MYSQL *mysql = NULL;

  if (mysql_library_init(argc, argv, NULL)) {
    fprintf(stderr, "could not initialize MySQL client library\n");
    exit(1);
  }

  mysql = mysql_init(mysql);

  if (!mysql) {
    puts("Init faild, out of memory?");
    return EXIT_FAILURE;
  }

  mysql_options(mysql, MYSQL_READ_DEFAULT_FILE, (void *)"./my.cnf");

  if (!mysql_real_connect(mysql, /* MYSQL structure to use */
                          NULL,  /* server hostname or IP address */
                          NULL,  /* mysql user */
                          NULL,  /* password */
                          NULL,  /* default database to use, NULL for none */
                          0,     /* port number, 0 for default */
                          NULL,  /* socket file or named pipe name */
                          CLIENT_FOUND_ROWS /* connection flags */)) {
    puts("Connect failed\n");
  } else {
    puts("Connect OK\n");
  }

  if (mysql_select_db(mysql, "test")) {
    puts("Failed to select database\n");
  }

  for (int i = 0; i < 10; ++i) {

    if (mysql_query(mysql, "SELECT * FROM tab_foo")) {
      printf("Query failed: %s\n", mysql_error(mysql));

      if (!mysql_real_connect(mysql, /* MYSQL structure to use */
                              NULL,  /* server hostname or IP address */
                              NULL,  /* mysql user */
                              NULL,  /* password */
                              NULL, /* default database to use, NULL for none */
                              0,    /* port number, 0 for default */
                              NULL, /* socket file or named pipe name */
                              CLIENT_FOUND_ROWS /* connection flags */)) {
        puts("Reconnect failed\n");
      } else {
        puts("Reconnect OK\n");
      }

    } else {
      MYSQL_RES *result = mysql_store_result(mysql);

      if (!result) {
        printf("Couldn't get results set: %s\n", mysql_error(mysql));
      } else {
        my_ulonglong rows = mysql_num_rows(result);

        printf("Current result set has %lu rows\n", (unsigned long)rows);

        mysql_free_result(result);
      }
    }

    printf("sleeping... (i=%d)\n", i);
    usleep(1000000 * 5);
  }

  mysql_close(mysql);

  mysql_library_end();

  return EXIT_SUCCESS;
}
```
