### PR TITLE
Automatic fetch sqlpp11 and date libraries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 sudo: required
-dist: trusty
+dist: focial
 
 services:
   - mysql

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.14)
 include(CheckCXXSymbolExists)
 project (sqlpp11-connector-mysql)
 enable_testing()
@@ -37,43 +37,12 @@ find_package(MySql REQUIRED)
 
 message(STATUS "Using ${CMAKE_CXX_COMPILER} (compiler id: ${CMAKE_CXX_COMPILER_ID})")
 
-set(DATE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../date/include" CACHE FILEPATH "Path to Howard Hinnant's date library")
-
-if(NOT EXISTS ${DATE_INCLUDE_DIR}/date/date.h)
-	message(SEND_ERROR "Can't find file date/date.h")
-	message("Can't find date/date.h in ${DATE_INCLUDE_DIR} ")
-	message("Please either")
-	message("  - git clone https://github.com/howardhinnant/date ${DATE_INCLUDE_DIR}")
-	message("  - set DATE_INCLUDE_DIR to point to the dir containing date/date.h from the date library")
-	message("  - e.g. download and unzip a current version from https://github.com/howardhinnant/date to ../date")
-	message("  -      -DDATE_INCLUDE_DIR=../date/include}")
-	message("")
-else()
-	message("including date from ${DATE_INCLUDE_DIR}")
-endif()
-
-set(SQLPP11_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../sqlpp11/include" CACHE FILEPATH "Path to sqlpp11 includes")
-
-if(NOT EXISTS ${SQLPP11_INCLUDE_DIR}/sqlpp11/sqlpp11.h)
-	message(SEND_ERROR "Can't find file sqlpp11/sqlpp11.h")
-	message("Can't find sqlpp11/sqlpp11.h in ${SQLPP11_INCLUDE_DIR} ")
-	message("Please either")
-	message("  - git clone https://github.com/rbock/sqlpp11 ${SQLPP11_INCLUDE_DIR}")
-	message("  - download and unzip a current version from https://github.com/rbock/sqlpp11 to ${SQLPP11_INCLUDE_DIR}")
-	message("  - set SQLPP11_INCLUDE_DIR to point to the dir containing sqlpp11/sqlpp11.h")
-	message("")
-else()
-	message("including sqlpp11 from ${SQLPP11_INCLUDE_DIR}")
-endif()
-
+add_subdirectory(dependencies)
 
 IF(MSVC)
     add_definitions(-DNOMINMAX)
 ENDIF()
 
-include_directories("${SQLPP11_INCLUDE_DIR}")
-include_directories("${DATE_INCLUDE_DIR}")
-include_directories("${MYSQL_INCLUDE_DIRS}")
 set(include_dir "${PROJECT_SOURCE_DIR}/include")
 file(GLOB_RECURSE sqlpp_headers ${include_dir}/*.h ${SQLPP11_INCLUDE_DIR}/*.h)
 include_directories(${include_dir})
@@ -86,4 +55,3 @@ endif()
 
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/sqlpp11" DESTINATION include)
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ License Hint:
 -------------
 The code is distributed under BSD License, but if you build the library, then the binary will be linked dynamically to mysqlclient, which is published under GPL or commercial license as of this writing. The resulting binary might therefore fall under GPL. To avoid this, an option to link against the equivalent MariaDB connector (under LGPL) is provided: see the build instructions below.
 
+Adding in you project:
+----------------------
+```
+include(FetchContent)
+
+FetchContent_Declare(sqlpp_mysql
+    GIT_REPOSITORY  https://github.com/GCarneiroA/sqlpp11-connector-mysql
+    GIT_TAG         origin/master
+)
+FetchContent_MakeAvailable(sqlpp_mysql)
+
+# Add link libraries to target "just_an_example"
+target_link_libraries(just_an_example sqlpp11::mysql)
+```
+
 Sample Code:
 ------------
 See for instance test/SampleTest.cpp

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ License Hint:
 -------------
 The code is distributed under BSD License, but if you build the library, then the binary will be linked dynamically to mysqlclient, which is published under GPL or commercial license as of this writing. The resulting binary might therefore fall under GPL. To avoid this, an option to link against the equivalent MariaDB connector (under LGPL) is provided: see the build instructions below.
 
-Adding in you project:
-----------------------
+Adding in you project (CMakeLists.txt):
+---------------------------------------
 ```
 include(FetchContent)
 

--- a/cmake/FindMySql.cmake
+++ b/cmake/FindMySql.cmake
@@ -45,12 +45,6 @@ else()
 	MESSAGE("LIB: ${MYSQL_LIBRARY}")
 endif()
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MYSQL
-  FOUND_VAR MYSQL_FOUND
-  REQUIRED_VARS MYSQL_LIBRARY MYSQL_INCLUDE_DIR
-  )
-
 mark_as_advanced(
   MYSQL_LIBRARY
   MYSQL_INCLUDE_DIR
@@ -58,3 +52,9 @@ mark_as_advanced(
 
 set(MYSQL_INCLUDE_DIRS ${MYSQL_INCLUDE_DIR})
 set(MYSQL_LIBRARIES ${MYSQL_LIBRARY})
+if(NOT TARGET MySQL::MySQL)
+	add_library(MySQL::MySQL UNKNOWN IMPORTED)
+	set_target_properties(MySQL::MySQL PROPERTIES
+		IMPORTED_LOCATION				"${MYSQL_LIBRARY}"
+		INTERFACE_INCLUDE_DIRECTORIES	"${MYSQL_INCLUDE_DIRS}")
+endif()

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+include(FetchContent)
+
+FetchContent_Declare(sqlpp11
+    GIT_REPOSITORY  https://github.com/rbock/sqlpp11
+    GIT_TAG         origin/master
+)
+
+FetchContent_MakeAvailable(sqlpp11)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(sqlpp-mysql SHARED)
+add_library(sqlpp-mysql )
 add_library(sqlpp11::mysql ALIAS sqlpp-mysql)
 
 target_sources(sqlpp-mysql

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,23 +1,42 @@
 
-add_library(sqlpp-mysql )
+add_library(sqlpp-mysql SHARED)
 add_library(sqlpp11::mysql ALIAS sqlpp-mysql)
 
-target_sources(sqlpp-mysql
-	PRIVATE
+add_library(sqlpp-mysql-static STATIC)
+add_library(sqlpp11::mysql::static ALIAS sqlpp-mysql-static)
+
+set(sqlpp_SRCs
 	connection.cpp
 	prepared_statement.cpp
 	char_result.cpp
 	bind_result.cpp
 	detail/connection_handle.cpp)
 
+target_sources(sqlpp-mysql PRIVATE ${sqlpp_SRCs})
+target_sources(sqlpp-mysql-static PRIVATE ${sqlpp_SRCs})
+
 target_link_libraries(sqlpp-mysql
 	PUBLIC sqlpp11::sqlpp11
 	MySQL::MySQL
 )
+
+target_link_libraries(sqlpp-mysql-static
+	PUBLIC sqlpp11::sqlpp11
+	MySQL::MySQL
+)
+
+if (NOT MSVC)
+	set_target_properties(sqlpp-mysql-static PROPERTIES OUTPUT_NAME sqlpp-mysql)
+endif()
 
 target_include_directories(sqlpp-mysql INTERFACE
 	"$<BUILD_INTERFACE:${sqlpp11-connector-mysql_SOURCE_DIR}/include>"
 	$<INSTALL_INTERFACE:include>
 )
 
-install(TARGETS sqlpp-mysql DESTINATION lib)
+target_include_directories(sqlpp-mysql-static INTERFACE
+	"$<BUILD_INTERFACE:${sqlpp11-connector-mysql_SOURCE_DIR}/include>"
+	$<INSTALL_INTERFACE:include>
+)
+
+install(TARGETS sqlpp-mysql sqlpp-mysql-static DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,23 @@
-add_library(sqlpp-mysql
-		connection.cpp
-		prepared_statement.cpp
-		char_result.cpp
-		bind_result.cpp
-		detail/connection_handle.cpp)
+
+add_library(sqlpp-mysql SHARED)
+add_library(sqlpp11::mysql ALIAS sqlpp-mysql)
+
+target_sources(sqlpp-mysql
+	PRIVATE
+	connection.cpp
+	prepared_statement.cpp
+	char_result.cpp
+	bind_result.cpp
+	detail/connection_handle.cpp)
+
+target_link_libraries(sqlpp-mysql
+	PUBLIC sqlpp11::sqlpp11
+	MySQL::MySQL
+)
+
+target_include_directories(sqlpp-mysql INTERFACE
+	"$<BUILD_INTERFACE:${sqlpp11-connector-mysql_SOURCE_DIR}/include>"
+	$<INSTALL_INTERFACE:include>
+)
 
 install(TARGETS sqlpp-mysql DESTINATION lib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,11 @@
 macro (build_and_run arg)
 	# Add headers to sources to enable file browsing in IDEs
 	add_executable(Sqlpp11MySQL${arg} ${arg}.cpp ${sqlpp_headers})
-	target_link_libraries(Sqlpp11MySQL${arg} sqlpp-mysql)
+	if (NOT MSVC)
+		target_link_libraries(Sqlpp11MySQL${arg} sqlpp-mysql)
+	else()
+		target_link_libraries(Sqlpp11MySQL${arg} sqlpp-mysql-static)
+	endif()
 	target_link_libraries(Sqlpp11MySQL${arg} Threads::Threads)
 	target_link_libraries(Sqlpp11MySQL${arg} "${MYSQL_LIBRARIES}")
 	if (NOT MSVC)


### PR DESCRIPTION
Using:

In deps/CMakeLists.txt:

```
include(FetchContent)

FetchContent_Declare(sqlpp_mysql
    GIT_REPOSITORY  https://github.com/rbock/sqlpp11-connector-mysql
    GIT_TAG         origin/master
)

FetchContent_GetProperties(sqlpp_mysql)
if (NOT sqlpp_mysql_POPULATED)
    FetchContent_Populate(sqlpp_mysql)
    add_subdirectory(${sqlpp_mysql_SOURCE_DIR} ${sqlpp_mysql_BINARY_DIR})
endif()
```

In src/CMakeLists.txt

```
add_executable(test)
target_link_libraries(test PUBLIC sqlpp-mysql::sqlpp-mysql)

target_sources(test PRIVATE main.cpp)
```

Minimum cpp:
```
#include <sqlpp11/mysql/mysql.h>

namespace mysql = sqlpp::mysql;

int main()
{
    mysql::global_library_init();
    return 0;
}
```

