### PR TITLE
Set CMake package version automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
-project(sqlpp11-connector-mysql
-    LANGUAGES CXX
-    VERSION 0.29
-)
+project(sqlpp11-connector-mysql LANGUAGES CXX)
+
+file(READ ${CMAKE_CURRENT_LIST_DIR}/include/sqlpp11/mysql/mysql.h mysql_h_contents)
+string(REGEX MATCH "#define SQLPP11_MYSQL_VERSION_MAJOR *([0-9a-zA-Z_]*)" NULL_OUT ${mysql_h_contents})
+set(VERSION_MAJOR ${CMAKE_MATCH_1})
+string(REGEX MATCH "#define SQLPP11_MYSQL_VERSION_MINOR *([0-9a-zA-Z_]*)" NULL_OUT ${mysql_h_contents})
+set(VERSION_MINOR ${CMAKE_MATCH_1})
+set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/sqlpp11/mysql/mysql.h
+++ b/include/sqlpp11/mysql/mysql.h
@@ -30,4 +30,7 @@
 #include <sqlpp11/mysql/connection.h>
 #include <sqlpp11/mysql/char_result.h>
 
+#define SQLPP11_MYSQL_VERSION_MAJOR    0
+#define SQLPP11_MYSQL_VERSION_MINOR   30
+
 #endif

--- a/include/sqlpp11/mysql/mysql.h
+++ b/include/sqlpp11/mysql/mysql.h
@@ -31,6 +31,6 @@
 #include <sqlpp11/mysql/char_result.h>
 
 #define SQLPP11_MYSQL_VERSION_MAJOR    0
-#define SQLPP11_MYSQL_VERSION_MINOR   30
+#define SQLPP11_MYSQL_VERSION_MINOR   29
 
 #endif

--- a/pre-push
+++ b/pre-push
@@ -12,4 +12,11 @@ minor=${BASH_REMATCH[1]}
 
 version="$major.$minor"
 
-git tag -a $version -m "Version $version"
+git tag | grep -Fx $version > /dev/null
+found=$?
+if [[ $found == 0 ]]; then
+    echo "Tag $version already exists"
+else
+    echo "Create new tag $version"
+    git tag -a $version -m "Version $version" || exit 1
+fi

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+content=`cat include/sqlpp11/mysql/mysql.h`
+
+pattern='#define SQLPP11_MYSQL_VERSION_MAJOR *([0-9a-zA-Z_]*)'
+[[ $content =~ $pattern ]]
+major=${BASH_REMATCH[1]}
+
+pattern='#define SQLPP11_MYSQL_VERSION_MINOR *([0-9a-zA-Z_]*)'
+[[ $content =~ $pattern ]]
+minor=${BASH_REMATCH[1]}
+
+version="$major.$minor"
+
+git tag -a $version -m "Version $version"


### PR DESCRIPTION
I decided to take an approach that is used in msgpack-c library (see https://github.com/msgpack/msgpack-c/blob/cpp_master/CMakeLists.txt#L10):

- Define library version as `SQLPP11_MYSQL_VERSION_MAJOR` and
  `SQLPP11_MYSQL_VERSION_MINOR` macro in include/sqlpp11/mysql/mysql.h
- Set CMake package version depending on these values
- Add tag-release.sh script that creates a git tag using these values

It is not as nice as I want it to be, but I guess that there is no ideal solution for the problem.